### PR TITLE
chore: add rimraf to be able to use `rm -rf` platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,15 @@
   "repository": "git@github.com:radicle-dev/radicle-avatar.git",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist", "LICENSE-MIT", "LICENSE-APACHE"],
+  "files": [
+    "dist",
+    "LICENSE-MIT",
+    "LICENSE-APACHE"
+  ],
   "scripts": {
     "test": "yarn regenerate-fixtures && jest",
-    "clean": "rm -rf ./dist",
-    "regenerate-fixtures": "rm -rf ./fixtures.json && cargo run --example generate-fixtures",
+    "clean": "rimraf ./dist",
+    "regenerate-fixtures": "rimraf ./fixtures.json && cargo run --example generate-fixtures",
     "build": "yarn run clean && tsc --project tsconfig.package.json",
     "prepack": "yarn run build"
   },
@@ -19,5 +23,8 @@
     "jest": "^26.6.3",
     "ts-jest": "^26.5.6",
     "typescript": "^4.2.4"
+  },
+  "dependencies": {
+    "rimraf": "^3.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4188,6 +4188,7 @@ fsevents@^2.1.2:
   dependencies:
     "@types/jest": ^26.0.23
     jest: ^26.6.3
+    rimraf: ^3.0.2
     ts-jest: ^26.5.6
     typescript: ^4.2.4
   languageName: unknown


### PR DESCRIPTION
This is needed so we can fix the radicle-dev/radicle-upstream#2774.

Using [rimraf](https://www.npmjs.com/package/rimraf) allows us to delete files on any operating system without worrying about command support issues.